### PR TITLE
fix(sec): upgrade moment to 2.29.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "chmodr": "1.2.0",
         "download": "7.1.0",
         "fs-extra": "8.1.0",
-        "moment": "2.24.0",
+        "moment": "2.29.4",
         "rsync": "0.6.1",
         "showdown": "1.9.1"
       },
@@ -1139,9 +1139,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -2608,9 +2608,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chmodr": "1.2.0",
     "download": "7.1.0",
     "fs-extra": "8.1.0",
-    "moment": "2.24.0",
+    "moment": "2.29.4",
     "rsync": "0.6.1",
     "showdown": "1.9.1"
   },


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in moment 2.24.0
- [CVE-2022-31129](https://www.oscs1024.com/hd/CVE-2022-31129)


### What did I do？
Upgrade moment from 2.24.0 to 2.29.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS